### PR TITLE
Fix typo on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 node-geste
 ==========
 
-> A small binary that calls a requirable jest exectuable
+> A small binary that calls a requirable jest executable
 
 Install
 -------


### PR DESCRIPTION
This PR fixes a typo on the `README.md` file (`s/exectuable/executable`).